### PR TITLE
Fix string function compiler warnings from cmdinput_readline.c

### DIFF
--- a/console/cmdinput_readline.c
+++ b/console/cmdinput_readline.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <readline/readline.h>
 #include <readline/history.h>


### PR DESCRIPTION
```
cmdinput_readline.c: In function ‘cp_console_compl_cmdgen’:
cmdinput_readline.c:41:13: warning: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
   textlen = strlen(text);
             ^
cmdinput_readline.c:41:13: warning: incompatible implicit declaration of built-in function ‘strlen’
cmdinput_readline.c:41:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:43:43: warning: implicit declaration of function ‘strncmp’ [-Wimplicit-function-declaration]
  while (commands[counter].name != NULL && strncmp(text, commands[counter].name, textlen)) {
                                           ^
cmdinput_readline.c:49:18: warning: implicit declaration of function ‘strdup’ [-Wimplicit-function-declaration]
   char *buffer = strdup(commands[counter].name);
                  ^
cmdinput_readline.c:49:18: warning: incompatible implicit declaration of built-in function ‘strdup’
cmdinput_readline.c: In function ‘cp_console_compl_flagsgen’:
cmdinput_readline.c:61:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^
cmdinput_readline.c:61:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:69:18: warning: incompatible implicit declaration of built-in function ‘strdup’
   char *buffer = strdup(load_flags[counter].name);
                  ^
cmdinput_readline.c: In function ‘cp_console_compl_loggen’:
cmdinput_readline.c:81:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^
cmdinput_readline.c:81:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:89:18: warning: incompatible implicit declaration of built-in function ‘strdup’
   char *buffer = strdup(log_levels[counter].name);
                  ^
cmdinput_readline.c: In function ‘cp_console_compl_plugingen’:
cmdinput_readline.c:101:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^
cmdinput_readline.c:101:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:116:19: warning: incompatible implicit declaration of built-in function ‘strdup’
    char *buffer = strdup(plugins[counter]->identifier);
```