### PR TITLE
Accept dlopen in libc too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,6 +211,11 @@ if test "$with_dlopen" != no && test "$with_libltdl" != yes; then
     AC_CHECK_LIB([dl], [dlopen],
       [LIBS_DL="-ldl $LIBS_DL"; dlmechanism=dlopen]))
 fi
+if test "$with_dlopen" != no && test "$with_libltdl" != yes; then
+  AC_CHECK_HEADER([dlfcn.h],
+    AC_CHECK_FUNC([dlopen],
+      [LIBS_DL="$LIBS_DL"; dlmechanism=dlopen]))
+fi
 if test "$dlmechanism" = none && test "$with_libltdl" != no && test "$with_dlopen" != yes; then  
   AC_CHECK_HEADER([ltdl.h],
     AC_CHECK_LIB([ltdl], [lt_dlopen],


### PR DESCRIPTION
netbsd doesn't have a separate libdl, dlopen is in libc.