### PR TITLE
Add support for plugins in Kodi's addon format

### DIFF
--- a/libcpluff/context.c
+++ b/libcpluff/context.c
@@ -197,6 +197,7 @@ CP_C_API cp_context_t * cp_create_context(cp_status_t *error) {
 		env->argc = 0;
 		env->argv = NULL;
 		env->plugin_descriptor_name = CP_PLUGIN_DESCRIPTOR;
+		env->plugin_descriptor_root_element = CP_PLUGIN_ROOT_ELEMENT;
 		env->plugin_listeners = list_create(LISTCOUNT_T_MAX);
 		env->loggers = list_create(LISTCOUNT_T_MAX);
 		env->log_min_severity = CP_LOG_NONE;
@@ -272,6 +273,13 @@ CP_C_API cp_context_t * cp_create_context(cp_status_t *error) {
 	
 	// Return the context (or NULL on failure) 
 	return context;
+}
+
+CP_C_API void cp_set_plugin_descriptor_root_element(cp_context_t *context, const char *root) {
+	CHECK_NOT_NULL(context);
+	CHECK_NOT_NULL(context->env);
+	CHECK_NOT_NULL(root);
+	context->env->plugin_descriptor_root_element = root;
 }
 
 CP_C_API void cp_set_plugin_descriptor_name(cp_context_t *context, const char *name) {

--- a/libcpluff/context.c
+++ b/libcpluff/context.c
@@ -196,6 +196,7 @@ CP_C_API cp_context_t * cp_create_context(cp_status_t *error) {
 #endif
 		env->argc = 0;
 		env->argv = NULL;
+		env->plugin_descriptor_name = CP_PLUGIN_DESCRIPTOR;
 		env->plugin_listeners = list_create(LISTCOUNT_T_MAX);
 		env->loggers = list_create(LISTCOUNT_T_MAX);
 		env->log_min_severity = CP_LOG_NONE;
@@ -271,6 +272,13 @@ CP_C_API cp_context_t * cp_create_context(cp_status_t *error) {
 	
 	// Return the context (or NULL on failure) 
 	return context;
+}
+
+CP_C_API void cp_set_plugin_descriptor_name(cp_context_t *context, const char *name) {
+	CHECK_NOT_NULL(context);
+	CHECK_NOT_NULL(context->env);
+	CHECK_NOT_NULL(name);
+	context->env->plugin_descriptor_name = name;
 }
 
 CP_C_API void cp_destroy_context(cp_context_t *context) {

--- a/libcpluff/cpluff.h
+++ b/libcpluff/cpluff.h
@@ -1033,6 +1033,15 @@ CP_C_API void cp_destroy(void);
 CP_C_API cp_context_t * cp_create_context(cp_status_t *status);
 
 /**
+ * Changes the file name in the plug-in the plug-in descriptor is loaded from.
+ * The default name is "plugin.xml"
+ *
+ * @param ctx the context to change the plug-in descriptor file name in
+ * @param name the new plug-in descriptor file name
+ */
+CP_C_API void cp_set_plugin_descriptor_name(cp_context_t *ctx, const char *name);
+
+/**
  * Destroys the specified plug-in context and releases the associated resources.
  * Stops and uninstalls all plug-ins in the context. The context must not be
  * accessed after calling this function.

--- a/libcpluff/cpluff.h
+++ b/libcpluff/cpluff.h
@@ -1042,6 +1042,16 @@ CP_C_API cp_context_t * cp_create_context(cp_status_t *status);
 CP_C_API void cp_set_plugin_descriptor_name(cp_context_t *ctx, const char *name);
 
 /**
+ * Changes the XML root element's name in plug-in descriptor.
+ * This also changes the attribute name to be used in the "import" element.
+ * The default name is "plugin".
+ *
+ * @param ctx the context to change the plug-in descriptor's XML root element's name in
+ * @param root the new XML root element name
+ */
+CP_C_API void cp_set_plugin_descriptor_root_element(cp_context_t *ctx, const char *root);
+
+/**
  * Destroys the specified plug-in context and releases the associated resources.
  * Stops and uninstalls all plug-ins in the context. The context must not be
  * accessed after calling this function.

--- a/libcpluff/internal.h
+++ b/libcpluff/internal.h
@@ -82,6 +82,9 @@ extern "C" {
 /// Plugin descriptor's default file name
 #define CP_PLUGIN_DESCRIPTOR "plugin.xml"
 
+/// Plugin descriptor's default root xml element
+#define CP_PLUGIN_ROOT_ELEMENT "plugin"
+
 
 /* ------------------------------------------------------------------------
  * Macros
@@ -156,6 +159,9 @@ struct cp_plugin_env_t {
 	
 	/// Plugin descriptor file name
 	const char *plugin_descriptor_name;
+
+	/// Plugin descriptor's XML root element
+	const char *plugin_descriptor_root_element;
 
 	/// Installed plug-in listeners 
 	list_t *plugin_listeners;

--- a/libcpluff/internal.h
+++ b/libcpluff/internal.h
@@ -79,6 +79,9 @@ extern "C" {
 /// Logging limit for no logging
 #define CP_LOG_NONE 1000
 
+/// Plugin descriptor's default file name
+#define CP_PLUGIN_DESCRIPTOR "plugin.xml"
+
 
 /* ------------------------------------------------------------------------
  * Macros
@@ -151,6 +154,9 @@ struct cp_plugin_env_t {
 	/// An array of startup arguments
 	char **argv;
 	
+	/// Plugin descriptor file name
+	const char *plugin_descriptor_name;
+
 	/// Installed plug-in listeners 
 	list_t *plugin_listeners;
 	

--- a/libcpluff/pdescriptor.c
+++ b/libcpluff/pdescriptor.c
@@ -60,9 +60,6 @@
 /// Initial configuration element value size 
 #define CP_CFG_ELEMENT_VALUE_INITSIZE 64
 
-/// Plugin descriptor name 
-#define CP_PLUGIN_DESCRIPTOR "plugin.xml"
-
 
 /* ------------------------------------------------------------------------
  * Internal data types
@@ -1150,14 +1147,14 @@ CP_C_API cp_plugin_info_t * cp_load_plugin_descriptor(cp_context_t *context, con
 		if (path[path_len - 1] == CP_FNAMESEP_CHAR) {
 			path_len--;
 		}
-		file = malloc((path_len + strlen(CP_PLUGIN_DESCRIPTOR) + 2) * sizeof(char));
+		file = malloc((path_len + strlen(context->env->plugin_descriptor_name) + 2) * sizeof(char));
 		if (file == NULL) {
 			status = CP_ERR_RESOURCE;
 			break;
 		}
 		strcpy(file, path);
 		file[path_len] = CP_FNAMESEP_CHAR;
-		strcpy(file + path_len + 1, CP_PLUGIN_DESCRIPTOR);
+		strcpy(file + path_len + 1, context->env->plugin_descriptor_name);
 
 		// Open the file 
 		if ((fh = fopen(file, "rb")) == NULL) {

--- a/libcpluff/pdescriptor.c
+++ b/libcpluff/pdescriptor.c
@@ -515,13 +515,14 @@ static void CP_XMLCALL character_data_handler(
  */
 static void CP_XMLCALL start_element_handler(
 	void *userData, const XML_Char *name, const XML_Char **atts) {
+	ploader_context_t *plcontext = userData;
 	static const XML_Char * const req_plugin_atts[] = { "id", NULL };
 	static const XML_Char * const opt_plugin_atts[] = { "name", "version", "provider-name", NULL };
 	static const XML_Char * const req_bwcompatibility_atts[] = { NULL };
 	static const XML_Char * const opt_bwcompatibility_atts[] = { "abi", "api", NULL };
 	static const XML_Char * const req_cpluff_atts[] = { "version", NULL };
 	static const XML_Char * const opt_cpluff_atts[] = { NULL };
-	static const XML_Char * const req_import_atts[] = { "plugin", NULL };
+	const XML_Char * const req_import_atts[] = { plcontext->context->env->plugin_descriptor_root_element, NULL };
 	static const XML_Char * const opt_import_atts[] = { "version", "optional", NULL };
 	static const XML_Char * const req_runtime_atts[] = { "library", NULL };
 	static const XML_Char * const opt_runtime_atts[] = { "funcs", NULL };
@@ -529,14 +530,13 @@ static void CP_XMLCALL start_element_handler(
 	static const XML_Char * const opt_ext_point_atts[] = { "name", "schema", NULL };
 	static const XML_Char * const req_extension_atts[] = { "point", NULL };
 	//static const XML_Char * const opt_extension_atts[] = { "id", "name", NULL };
-	ploader_context_t *plcontext = userData;
 	unsigned int i;
 
 	// Process element start 
 	switch (plcontext->state) {
 
 		case PARSER_BEGIN:
-			if (!strcmp(name, "plugin")) {
+			if (!strcmp(name, plcontext->context->env->plugin_descriptor_root_element)) {
 				plcontext->state = PARSER_PLUGIN;
 				if (!check_attributes(plcontext, name, atts,
 						req_plugin_atts, opt_plugin_atts)) {
@@ -746,7 +746,7 @@ static void CP_XMLCALL start_element_handler(
 					import->plugin_id = NULL;
 					import->version = NULL;
 					for (i = 0; atts[i] != NULL; i += 2) {
-						if (!strcmp(atts[i], "plugin")) {
+						if (!strcmp(atts[i], req_import_atts[0])) {
 							import->plugin_id
 								= parser_strdup(plcontext, atts[i+1]);
 						} else if (!strcmp(atts[i], "version")) {
@@ -829,7 +829,7 @@ static void CP_XMLCALL end_element_handler(
 	switch (plcontext->state) {
 
 		case PARSER_PLUGIN:
-			if (!strcmp(name, "plugin")) {
+			if (!strcmp(name, plcontext->context->env->plugin_descriptor_root_element)) {
 				
 				// Readjust memory allocated for extension points, if necessary 
 				if (plcontext->ext_points_size != plcontext->plugin->num_ext_points) {

--- a/test/ploading.c
+++ b/test/ploading.c
@@ -42,6 +42,21 @@ void loadonlymaximal(void) {
 	check(errors == 0);
 }
 
+void loadonlymaximaladdon(void) {
+	cp_context_t *ctx;
+	cp_plugin_info_t *plugin;
+	cp_status_t status;
+	int errors;
+
+	ctx = init_context(CP_LOG_ERROR, &errors);
+	cp_set_plugin_descriptor_name(ctx, "addon.xml");
+	cp_set_plugin_descriptor_root_element(ctx, "addon");
+	check((plugin = cp_load_plugin_descriptor(ctx, plugindir("maximal"), &status)) != NULL && status == CP_OK);
+	cp_release_info(ctx, plugin);
+	cp_destroy();
+	check(errors == 0);
+}
+
 void loadonlymaximalfrommemory(void) {
 	cp_context_t *ctx;
 	cp_plugin_info_t *plugin;

--- a/test/plugins/maximal/addon.xml
+++ b/test/plugins/maximal/addon.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<addon id="maximal" name="Maximal" version="1.0.0.max" provider-name="Maximal Provider">
+	<backwards-compatibility abi="1.0" api="0.8"/>
+	<requires>
+		<c-pluff version="999.3.4"/>
+		<import addon="dependency1" version="0.1" optional="true"/>
+		<import addon="dependency2" version="0.2"/>
+		<import addon="dependency3" optional="true"/>
+		<import addon="dependency4"/>
+	</requires>
+	<runtime library="nonexisting" funcs="funcs"/>
+	<extension-point id="extpt1" name="Extension Point 1" schema="ext1.xsd"/>
+	<extension-point id="extpt2" name="Extension Point 2"/>
+	<extension-point id="extpt3" schema="extpt3.xsd"/>
+	<extension-point id="extpt4"/>
+	<extension point="nonexisting.extptA" id="ext1" name="Extension 1">
+		Extension data begins
+		<structure>
+			<parameter>parameter</parameter>
+			<parameter>param2</parameter>
+			<!-- <parameter>commented out parameter</parameter> -->
+			<assertion>1&lt;2</assertion>
+			<deeper>
+				<struct>
+					<is>here</is>
+				</struct>
+			</deeper>
+			Structure ends
+		</structure>
+	</extension>
+	<extension point="nonexisting.extptB" id="ext2"/>
+	<extension point="maximal.extpt1" name="Extension 3"/>
+	<extension point="maximal.extpt2"/>
+</addon>

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -31,6 +31,7 @@ updatelogger
 logmsg
 islogged
 loadonlymaximal
+loadonlymaximaladdon
 loadonlymaximalfrommemory
 loadminimal
 loadmaximal


### PR DESCRIPTION
Kodi maintains a fork of C-Pluff in https://github.com/xbmc/xbmc/tree/master/lib/cpluff .
To let Kodi use a pre-built C-Pluff libraries as shipped by distributions C-Pluff needs to be able to open the changed plugin format. The changes extend the API without breaking existing ABI to load Kodi's addons by allowing custom file name instead of the default "plugin.xml" and allowing custom root XML element name.