### PR TITLE
provide pkg-config libcpluff.pc and libcpluffxx files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,8 @@ AC_CONFIG_SRCDIR([libcpluff/cpluff.h])
 AC_CONFIG_AUX_DIR([auxliary])
 AC_CONFIG_HEADERS([config.h])
 
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
 
 # Version information
 # -------------------
@@ -386,11 +388,13 @@ AC_SUBST(CPLUFF_LOADER)
 # Output Makefiles
 # ----------------
 AC_CONFIG_FILES([Makefile
+libcpluff/libcpluff.pc
 libcpluff/Makefile
 libcpluff/cpluffdef.h
 libcpluff/docsrc/Makefile
 libcpluff/docsrc/Doxyfile-ref
 libcpluff/docsrc/Doxyfile-impl
+libcpluffxx/libcpluffxx.pc
 libcpluffxx/Makefile
 libcpluffxx/cpluffxx/Makefile
 libcpluffxx/cpluffxx/sharedptr.h

--- a/libcpluff/Makefile.am
+++ b/libcpluff/Makefile.am
@@ -27,6 +27,8 @@ libcpluff_la_LDFLAGS = -no-undefined -version-info $(CP_C_LIB_VERSION)
 
 include_HEADERS = cpluff.h cpluffdef.h
 
+pkgconfig_DATA = libcpluff.pc
+
 doc: refdoc
 
 refdoc: doc/reference/c-api/index.html

--- a/libcpluff/libcpluff.pc.in
+++ b/libcpluff/libcpluff.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+includedir=@includedir@
+libdir=@libdir@
+
+Name: libcpluff
+Description: C-Pluff, a plug-in framework for C
+URL: https://github.com/jlehtine/c-pluff
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lcpluff

--- a/libcpluffxx/Makefile.am
+++ b/libcpluffxx/Makefile.am
@@ -26,6 +26,8 @@ libcpluffxx_la_LDFLAGS = -no-undefined -version-info $(CP_CXX_LIB_VERSION)
 
 include_HEADERS = cpluffxx.h
 
+pkgconfig_DATA = libcpluffxx.pc
+
 doc: refdoc
 
 refdoc: doc/reference/cxx-api/index.html

--- a/libcpluffxx/libcpluffxx.pc.in
+++ b/libcpluffxx/libcpluffxx.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+includedir=@includedir@
+libdir=@libdir@
+
+Name: libcpluffxx
+Description: C-Pluff, a plug-in framework for C++
+URL: https://github.com/jlehtine/c-pluff
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lcpluffxx
+Requires.private: libcpluff


### PR DESCRIPTION
pkg-config makes it easy for consumers of the libraries to obtain the
required CFLAGS and LDFLAGS.

libcpluffxx requires header files from libcpluff, therefore it needs
a Requires.private: libcpluff

Signed-off-by: Olaf Hering <olaf@aepfle.de>